### PR TITLE
Improve BoardPanel focus for reliable drag operations

### DIFF
--- a/src/ChessGUI.java
+++ b/src/ChessGUI.java
@@ -1109,6 +1109,9 @@ public class ChessGUI {
             setBackground(new Color(24,28,28));
             setFocusable(true);            // wichtig für Keyboard-Shortcuts
             setDoubleBuffered(true);       // flüssiges Neuzeichnen beim Draggen
+            // Tastatur-Shortcuts und Drag&Drop reagieren erst zuverlässig,
+            // wenn das Panel selbst den Fokus hält
+            SwingUtilities.invokeLater(this::requestFocusInWindow);
 
             MouseAdapter ma = new MouseAdapter(){
                 @Override public void mousePressed(MouseEvent e){ onPress(e); }


### PR DESCRIPTION
## Summary
- Ensure the chess board panel requests focus when created so it can handle keyboard shortcuts and drag events reliably.

## Testing
- `javac --release 21 -encoding UTF-8 -d out src/*.java`
- `java -cp out ChessGUI` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_689bd353de40832699bfbc3f9116754c