### PR TITLE
Fix drag release handling in ChessGUI

### DIFF
--- a/src/ChessGUI.java
+++ b/src/ChessGUI.java
@@ -1094,6 +1094,7 @@ public class ChessGUI {
         private int dragX=0, dragY=0; // Mausposition
         private int dragOffsetX=0, dragOffsetY=0; // Offset zwischen Klickpunkt und Feld
         private Timer dragTimer=null;           // regelmäßiges Repaint für flüssiges Ziehen
+        private AWTEventListener globalMouse=null; // globaler Listener zum Abbrechen des Drags
 
         // --- Animation
         private boolean animating=false;
@@ -1196,7 +1197,19 @@ public class ChessGUI {
         }
         private void onRelease(MouseEvent e){
             if(!dragging) return;
+            endDrag();
 
+            int to = pointToSquare(e.getX(), e.getY());
+            if(to==-1){
+                selected=-1; legalFromSelected=List.of();
+                repaint();
+                return;
+            }
+
+            List<Move> candidates = legalFromSelected.stream()
+                    .filter(m -> m.to==to)
+                    .collect(Collectors.toList());
+            if(candidates.isEmpty()){
                 selected=-1; legalFromSelected=List.of();
                 repaint();
                 return;


### PR DESCRIPTION
## Summary
- Add missing global mouse listener field and clean up drag state
- Restore release logic to select valid move and handle promotions

## Testing
- `javac src/ChessGUI.java`


------
https://chatgpt.com/codex/tasks/task_b_689be085f4788326953fa5f14fbdf457