### PR TITLE
Improve drag handling for smoother chess piece movement

### DIFF
--- a/src/ChessGUI.java
+++ b/src/ChessGUI.java
@@ -1187,6 +1187,36 @@ public class ChessGUI {
             dragOffsetX = dragX - tl.x;
             dragOffsetY = dragY - tl.y;
 
+            // regelmäßiges Polling der Mausposition, falls außerhalb keine Events eintreffen
+            dragTimer = new Timer(1000/60, ev -> {
+                PointerInfo info = MouseInfo.getPointerInfo();
+                if(info != null){
+                    Point loc = info.getLocation();
+                    SwingUtilities.convertPointFromScreen(loc, BoardPanel.this);
+                    dragX = loc.x;
+                    dragY = loc.y;
+                }
+                repaint();
+            });
+            dragTimer.start();
+
+            // Globale Maus-Events beobachten, damit Drag außerhalb des Panels weiterläuft
+            globalMouse = ev -> {
+                if(!(ev instanceof MouseEvent me) || !dragging) return;
+                // Ereignisse vom Brett selbst ignorieren – die lokalen Listener kümmern sich darum
+                if(me.getComponent()==BoardPanel.this) return;
+                if(me.getID()==MouseEvent.MOUSE_DRAGGED){
+                    MouseEvent conv = SwingUtilities.convertMouseEvent(me.getComponent(), me, BoardPanel.this);
+                    dragX = conv.getX();
+                    dragY = conv.getY();
+                } else if(me.getID()==MouseEvent.MOUSE_RELEASED){
+                    MouseEvent conv = SwingUtilities.convertMouseEvent(me.getComponent(), me, BoardPanel.this);
+                    onRelease(conv);
+                }
+            };
+            Toolkit.getDefaultToolkit().addAWTEventListener(globalMouse,
+                    AWTEvent.MOUSE_EVENT_MASK | AWTEvent.MOUSE_MOTION_EVENT_MASK);
+
             repaint();
         }
         private void onDrag(MouseEvent e){


### PR DESCRIPTION
## Summary
- Poll global mouse pointer on drag timer so pieces keep up with cursor even when leaving the board
- Preserve drag reliability for pawns and other pieces by updating position outside local events

## Testing
- `javac src/ChessGUI.java`


------
https://chatgpt.com/codex/tasks/task_b_689be4e7cd7c83268a396f38f01dc18e