### PR TITLE
Stabilize chess board drag handling

### DIFF
--- a/src/ChessGUI.java
+++ b/src/ChessGUI.java
@@ -1094,7 +1094,26 @@ public class ChessGUI {
         private int dragX=0, dragY=0; // Mausposition
         private int dragOffsetX=0, dragOffsetY=0; // Offset zwischen Klickpunkt und Feld
         private Timer dragTimer=null;           // regelmäßiges Repaint für flüssiges Ziehen
-        private AWTEventListener globalMouse=null; // globaler Listener zum Abbrechen des Drags
+        // --- Drag capture via glass pane + window watcher
+        private JComponent glass = null;
+        private final MouseAdapter glassForwarder = new MouseAdapter() {
+            private MouseEvent toBoard(MouseEvent e){
+                return SwingUtilities.convertMouseEvent((Component)e.getSource(), e, BoardPanel.this);
+            }
+            @Override public void mouseDragged(MouseEvent e){
+                if (!dragging) return;
+                onDrag(toBoard(e));
+            }
+            @Override public void mouseMoved(MouseEvent e){
+                if (!dragging) return;
+                onDrag(toBoard(e));
+            }
+            @Override public void mouseReleased(MouseEvent e){
+                if (!dragging) return;
+                onRelease(toBoard(e));
+            }
+        };
+        private WindowAdapter windowWatcher = null;
 
         // --- Animation
         private boolean animating=false;
@@ -1109,16 +1128,32 @@ public class ChessGUI {
         private void endDrag() {
             if (dragTimer != null) {
                 dragTimer.stop();
-                dragTimer = null;
+                dragTimer = null;             // <-- ensure GC + no repeats
             }
-            if (globalMouse != null) {
-                Toolkit.getDefaultToolkit().removeAWTEventListener(globalMouse);
-                globalMouse = null;
-            }
+            uninstallGlass();                  // <-- NEW: always remove glass capture
+
             dragging = false;
             dragPiece = null;
             dragFrom = -1;
             dragOffsetX = dragOffsetY = 0;
+        }
+
+        private void installGlass(){
+            if (glass != null) return;
+            glass = (JComponent) frame.getGlassPane();
+            glass.setVisible(true);
+            glass.setOpaque(false);
+            glass.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+            glass.addMouseListener(glassForwarder);
+            glass.addMouseMotionListener(glassForwarder);
+        }
+        private void uninstallGlass(){
+            if (glass == null) return;
+            glass.removeMouseListener(glassForwarder);
+            glass.removeMouseMotionListener(glassForwarder);
+            glass.setCursor(Cursor.getDefaultCursor());
+            glass.setVisible(false);
+            glass = null;
         }
 
         BoardPanel(){
@@ -1138,6 +1173,20 @@ public class ChessGUI {
             addMouseListener(ma);
             addMouseMotionListener(ma);
 
+            // ESC cancels any stuck drag
+            getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "cancelDrag");
+            getActionMap().put("cancelDrag", new AbstractAction(){
+                @Override public void actionPerformed(ActionEvent e){ endDrag(); repaint(); }
+            });
+
+            // Cancel drag if the window deactivates / loses focus
+            windowWatcher = new WindowAdapter() {
+                @Override public void windowDeactivated(WindowEvent e){ endDrag(); }
+                @Override public void windowLostFocus(WindowEvent e){ endDrag(); }
+            };
+            frame.addWindowFocusListener(windowWatcher);
+            frame.addWindowListener(windowWatcher);
+
             // Shortcuts: H=Hint, U=Undo
             getInputMap(WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke('H'), "hint");
             getActionMap().put("hint", new AbstractAction(){ @Override public void actionPerformed(ActionEvent e){ onHint(); }});
@@ -1147,8 +1196,11 @@ public class ChessGUI {
 
         // ------ Animation API
         void animateMove(Board pre, Move m, Runnable done){
-            // WICHTIG: kein Drag darf während der Animation aktiv sein
+            // No drag allowed during animation
             endDrag();
+            selected = -1;                     // <-- NEW: clear UI overlays that could compete
+            legalFromSelected = List.of();
+            hintMove = null;
 
             animating=true; animStart=System.currentTimeMillis();
             animBoard=pre; animMove=m; animPiece=pre.at(m.from); animDone=done;
@@ -1172,6 +1224,9 @@ public class ChessGUI {
         private void onPress(MouseEvent e){
             if(e.getButton() != MouseEvent.BUTTON1) return;
 
+            // NEW: don’t start a drag while the AI/animation is running
+            if (busy || animating) { beep(); return; }
+
             requestFocusInWindow();
             int i = pointToSquare(e.getX(), e.getY());
             if(i==-1) return;
@@ -1179,41 +1234,34 @@ public class ChessGUI {
             boolean allowed = (p!=null && p.side==board.sideToMove && p.side==human);
             if(!allowed){ beep(); return; }
 
-            selected=i;
-            legalFromSelected = board.legalMoves().stream().filter(m -> m.from==selected).collect(Collectors.toList());
-
+            // Start capture and drag immediately to avoid missing early deltas
             dragging=true; dragFrom=i; dragPiece=p; dragX=e.getX(); dragY=e.getY();
             Point tl = boardIndexToVisualXY(i);
             dragOffsetX = dragX - tl.x;
             dragOffsetY = dragY - tl.y;
+            installGlass();
+
+            // Jetzt erst die Züge berechnen (darf länger dauern)
+            selected=i;
+            legalFromSelected = board.legalMoves().stream().filter(m -> m.from==selected).collect(Collectors.toList());
 
             // regelmäßiges Repaint, falls keine Drag-Events eintreffen
             dragTimer = new Timer(1000/60, ev -> repaint());
+            dragTimer.setCoalesce(true);
             dragTimer.start();
 
-            // Globale Maus-Events beobachten, damit Drag außerhalb des Panels weiterläuft
-            globalMouse = ev -> {
-                if(!(ev instanceof MouseEvent me) || !dragging) return;
-                // Ereignisse vom Brett selbst ignorieren – die lokalen Listener kümmern sich darum
-                if(me.getComponent()==BoardPanel.this) return;
-                if(me.getID()==MouseEvent.MOUSE_DRAGGED){
-                    MouseEvent conv = SwingUtilities.convertMouseEvent(me.getComponent(), me, BoardPanel.this);
-                    dragX = conv.getX();
-                    dragY = conv.getY();
-                } else if(me.getID()==MouseEvent.MOUSE_RELEASED){
-                    MouseEvent conv = SwingUtilities.convertMouseEvent(me.getComponent(), me, BoardPanel.this);
-                    onRelease(conv);
-                }
-            };
-            Toolkit.getDefaultToolkit().addAWTEventListener(globalMouse,
-                    AWTEvent.MOUSE_EVENT_MASK | AWTEvent.MOUSE_MOTION_EVENT_MASK);
-
+            // (Optional) If you keep the Toolkit listener, you can remove it now;
+            // glass pane makes it unnecessary.
             repaint();
         }
         private void onDrag(MouseEvent e){
             if(!dragging || busy || animating) return;
-            // Mausposition merken und Brett neu zeichnen
-            dragX=e.getX(); dragY=e.getY();
+            if ((e.getModifiersEx() & InputEvent.BUTTON1_DOWN_MASK) == 0) {
+                onRelease(e);
+                return;
+            }
+            dragX = e.getX();
+            dragY = e.getY();
             repaint();
         }
         private void onRelease(MouseEvent e){
@@ -1307,7 +1355,7 @@ public class ChessGUI {
             }
 
             // Check
-            if(board.isInCheck(board.sideToMove) && !animating){
+            if(board.isInCheck(board.sideToMove) && !animating && !dragging){
                 int k=board.kingSquare(board.sideToMove);
                 Point p=boardIndexToVisualXY(k);
                 g2.setColor(CHECK); g2.fillRect(p.x,p.y,TILE,TILE);
@@ -1390,7 +1438,7 @@ public class ChessGUI {
             }
 
             // Hint – kontrastreich: Overlays + Pfeil
-            if(hintMove!=null && !animating){
+            if(hintMove!=null && !animating && !dragging){
                 Point af=boardIndexToVisualXY(hintMove.from);
                 Point bf=boardIndexToVisualXY(hintMove.to);
 
@@ -1406,6 +1454,10 @@ public class ChessGUI {
                 g2.setColor(HINT_ARROW);
                 drawArrow(g2, ax, ay, ex, ey);
                 g2.setStroke(old);
+            }
+
+            if (System.getProperty("os.name", "").toLowerCase().contains("linux")) {
+                Toolkit.getDefaultToolkit().sync();
             }
 
             g2.dispose();


### PR DESCRIPTION
## Summary
- Forward glass pane drag and move events so drags continue off the board
- Auto-release when button1 is up, coalescing drag repaints to reduce jitter
- Skip hint/check overlays during drags and sync toolkit on Linux for smoother painting

## Testing
- `javac src/ChessGUI.java`


------
https://chatgpt.com/codex/tasks/task_b_689be90c368c83268665b0a769ff47c8