### PR TITLE
Add Stockfish path configuration and engine wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,24 @@ Java Swing basierte Schachoberfläche mit Drag & Drop.
 Compile and run using the included `ChessGUI` main method:
 
 ```bash
-javac --release 21 -encoding UTF-8 -d out src/ChessGUI.java
+javac --release 21 -encoding UTF-8 -d out src/ChessGUI.java src/StockfishEngine.java
 java -cp out ChessGUI
 ```
 
 Requires Java 21.
+
+## Stockfish Engine
+
+This project can make use of the external Stockfish chess engine. To enable it:
+
+1. Download a Stockfish binary from <https://stockfishchess.org/download/> and place it somewhere on your system.
+2. Create a file named `stockfish.path` in the project root. The first non-empty line should contain the absolute path to the Stockfish executable. Lines beginning with `#` are treated as comments.
+
+Example `stockfish.path`:
+
+```
+# Absolute path to your Stockfish binary
+/usr/games/stockfish
+```
+
+`StockfishEngine` reads this file on startup and validates that the executable exists and is runnable.

--- a/src/StockfishEngine.java
+++ b/src/StockfishEngine.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Minimal Stockfish engine helper that reads the path to the Stockfish
+ * executable from a configuration file. The configuration file is named
+ * {@code stockfish.path} and must contain the absolute path to the
+ * Stockfish binary in its first non-empty, non-comment line.
+ */
+public class StockfishEngine {
+    private final String path;
+
+    public StockfishEngine() {
+        this.path = loadPath();
+        validateExecutable();
+    }
+
+    /**
+     * Returns the configured path to the Stockfish executable.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    private String loadPath() {
+        Path config = Paths.get("stockfish.path");
+        if (!Files.exists(config)) {
+            throw new IllegalStateException("Missing configuration file stockfish.path");
+        }
+        try (BufferedReader br = Files.newBufferedReader(config)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                return line;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read stockfish.path", e);
+        }
+        throw new IllegalStateException("No path specified in stockfish.path");
+    }
+
+    private void validateExecutable() {
+        Path exec = Paths.get(path);
+        if (!Files.exists(exec)) {
+            throw new IllegalStateException("Stockfish executable not found: " + path);
+        }
+        if (!Files.isRegularFile(exec)) {
+            throw new IllegalStateException("Stockfish path is not a file: " + path);
+        }
+        if (!Files.isExecutable(exec)) {
+            throw new IllegalStateException("Stockfish file is not executable: " + path);
+        }
+    }
+}

--- a/stockfish.path
+++ b/stockfish.path
@@ -1,0 +1,2 @@
+# Absolute path to your Stockfish binary
+/usr/games/stockfish


### PR DESCRIPTION
## Summary
- add StockfishEngine helper that reads Stockfish executable path from `stockfish.path` and validates it
- provide configurable `stockfish.path` file and document how to set it up
- update README with Stockfish setup instructions

## Testing
- `javac --release 21 -encoding UTF-8 -d out src/ChessGUI.java src/StockfishEngine.java`


------
https://chatgpt.com/codex/tasks/task_b_689c9edcea4c8326b6d6e6e0cc6ed6f3